### PR TITLE
feat: message queue using tumbling windows

### DIFF
--- a/price/src/main/java/org/coin/price/dto/CryptoCoin.java
+++ b/price/src/main/java/org/coin/price/dto/CryptoCoin.java
@@ -7,11 +7,11 @@ import lombok.Getter;
 @Getter
 public class CryptoCoin  {
     private String coinName;
-    private Double price;
+    private String price;
     private Long timestamp;
 
     @Builder
-    public CryptoCoin(String coinName, Double price, Long timestamp) {
+    public CryptoCoin(String coinName, String price, Long timestamp) {
         this.coinName = coinName;
         this.price = price;
         this.timestamp = timestamp;

--- a/price/src/main/java/org/coin/price/dto/CurrentPrice.java
+++ b/price/src/main/java/org/coin/price/dto/CurrentPrice.java
@@ -19,7 +19,7 @@ public class CurrentPrice {
         }
     }
 
-    public Double getCurrentPrice(String coinName) {
+    public String getCurrentPrice(String coinName) {
         return this.currentPriceMap.get(coinName).getClosing_price();
     }
 }

--- a/price/src/main/java/org/coin/price/dto/PriceApiRequest.java
+++ b/price/src/main/java/org/coin/price/dto/PriceApiRequest.java
@@ -39,10 +39,6 @@ public class PriceApiRequest {
             "fluctate_rate_24H"})
     public static class PriceData {
         private String closing_price;
-
-        public Double getClosing_price() {
-            return Double.parseDouble(closing_price);
-        }
     }
 }
 

--- a/price/src/main/java/org/coin/price/queue/PriceMessageWindowBlockingQueue.java
+++ b/price/src/main/java/org/coin/price/queue/PriceMessageWindowBlockingQueue.java
@@ -1,0 +1,109 @@
+package org.coin.price.queue;
+
+import jakarta.annotation.PostConstruct;
+import lombok.extern.slf4j.Slf4j;
+import org.coin.price.dto.CryptoCoin;
+import org.coin.price.dto.CryptoCoinComparator;
+import org.coin.price.dto.PriceApiRequest;
+import org.coin.price.event.PriceMessageProduceEvent;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.io.BufferedReader;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.PriorityBlockingQueue;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Component
+public class PriceMessageWindowBlockingQueue implements MessageQueue<PriceMessageProduceEvent, List<CryptoCoin>> {
+    private ConcurrentHashMap<String, PriorityBlockingQueue<CryptoCoin>> priceHashMapPriorityQueue = new ConcurrentHashMap<>();
+    private ArrayList<String> coins = new ArrayList<>();
+    private final AtomicInteger coinsIndex = new AtomicInteger(0);
+    @Value("${price.api.initial-queue-size}")
+    private int queueSize;
+    @Value("${price.api.price-window-size}")
+    private int windowSize;
+
+    @PostConstruct
+    void init() {
+        log.debug("PriceMessageBlockingQueue init.");
+
+        try (InputStream inputStream = getClass().getClassLoader().getResourceAsStream("BaseCryptoList.txt")) {
+            coins = new BufferedReader(new InputStreamReader(inputStream, StandardCharsets.UTF_8))
+                    .lines()
+                    .collect(Collectors.toCollection(ArrayList::new));
+        } catch (Exception e) {
+            log.error("PriceMessageBlockingQueue PostConstruct Failed. : {}", e.getMessage());
+        }
+
+        coins.forEach(coinName -> priceHashMapPriorityQueue.put(coinName, new PriorityBlockingQueue<>(queueSize, new CryptoCoinComparator())));
+    }
+
+    @Override
+    public void produce(PriceMessageProduceEvent event) {
+        Long timestamp = event.timestamp();
+        Map<String, PriceApiRequest.PriceData> priceDataMap = event.priceDataMap();
+
+        priceDataMap.forEach((key, value) -> {
+            CryptoCoin coin = buildCryptoCoin(key, value, timestamp);
+            addPricePriorityBlockingQueue(key, coin);
+        });
+    }
+
+    private CryptoCoin buildCryptoCoin(String key, PriceApiRequest.PriceData value, Long timestamp) {
+        return CryptoCoin.builder()
+                .price(value.getClosing_price())
+                .coinName(key)
+                .timestamp(timestamp)
+                .build();
+    }
+
+    private void addPricePriorityBlockingQueue(String key, CryptoCoin coin) {
+        this.priceHashMapPriorityQueue.computeIfPresent(key, (k, blockingQueue) -> {
+            blockingQueue.put(coin);
+            return blockingQueue;
+        });
+    }
+
+    @Override
+    public List<CryptoCoin> consume() {
+        return tumblingWindow(
+                getCoinName()
+        );
+    }
+
+    private String getCoinName() {
+        return coins.get(getCoinsIndex());
+    }
+
+    private int getCoinsIndex() {
+        return coinsIndex.getAndAccumulate(
+                1,
+                (current, update) -> {
+                    if (current < coins.size() - 1) {
+                        return current + update;
+                    }
+                    return 0;
+                });
+    }
+
+    private List<CryptoCoin> tumblingWindow(String name) {
+        PriorityBlockingQueue<CryptoCoin> blockingQueue = priceHashMapPriorityQueue.get(name);
+        synchronized (blockingQueue) {
+            Map<String, CryptoCoin> map = new HashMap<>(windowSize + 1, 1.0f);
+
+            while (map.keySet().size() < windowSize && blockingQueue.peek() != null) {
+                CryptoCoin coin = blockingQueue.poll();
+                map.put(coin.getPrice(), coin);
+            }
+
+            return map.values().stream().toList();
+        }
+    }
+}

--- a/price/src/main/java/org/coin/price/service/PriceService.java
+++ b/price/src/main/java/org/coin/price/service/PriceService.java
@@ -9,7 +9,7 @@ import org.springframework.stereotype.Service;
 public class PriceService {
     private final CurrentPrice currentPrice;
 
-    public Double findPrice(String coinName) {
+    public String findPrice(String coinName) {
         return currentPrice.getCurrentPrice(coinName);
     }
 }

--- a/price/src/main/resources/application-dev.yaml
+++ b/price/src/main/resources/application-dev.yaml
@@ -5,6 +5,7 @@ price:
     rps: 4
     max-failures: 10
     initial-queue-size: 100
+    price-window-size: 5
 
 server:
   port: 8085

--- a/price/src/test/java/org/coin/price/queue/PriceMessageBlockingQueueTest.java
+++ b/price/src/test/java/org/coin/price/queue/PriceMessageBlockingQueueTest.java
@@ -88,17 +88,17 @@ class PriceMessageBlockingQueueTest {
                 () -> assertEquals(
                         finalSize/3,
                         priceHashMapPriorityQueue.get(coinName.get(0)).size(),
-                        "Array[0] must be " + finalSize/3
+                        coinName.get(0) + " PriorityBlockingQueue  must be " + finalSize/3
                 ),
                 () -> assertEquals(
                         finalSize/3,
                         priceHashMapPriorityQueue.get(coinName.get(1)).size(),
-                        "Array[1] must be " + finalSize/3
+                        coinName.get(1) + " PriorityBlockingQueue must be " + finalSize/3
                 ),
                 () -> assertEquals(
                         finalSize/3,
                         priceHashMapPriorityQueue.get(coinName.get(2)).size(),
-                        "Array[2] must be " + finalSize/3
+                        coinName.get(2) + " PriorityBlockingQueue must be " + finalSize/3
                 )
         );
     }
@@ -131,7 +131,7 @@ class PriceMessageBlockingQueueTest {
         }
 
         consumeExecutorService.shutdown();
-        assertTrue(produceExecutorService.awaitTermination(60, TimeUnit.SECONDS), "timeout.");
+        assertTrue(consumeExecutorService.awaitTermination(60, TimeUnit.SECONDS), "timeout.");
 
         // then
         assertAll(
@@ -139,17 +139,17 @@ class PriceMessageBlockingQueueTest {
                 () -> assertEquals(
                         0,
                         priceHashMapPriorityQueue.get(coinName.get(0)).size(),
-                        "Array[0] must be 0"
+                        coinName.get(0) + " PriorityBlockingQueue must be 0"
                 ),
                 () -> assertEquals(
                         0,
                         priceHashMapPriorityQueue.get(coinName.get(1)).size(),
-                        "Array[1] must be 0"
+                        coinName.get(1) + " PriorityBlockingQueue must be 0"
                 ),
                 () -> assertEquals(
                         0,
                         priceHashMapPriorityQueue.get(coinName.get(2)).size(),
-                        "Array[2] must be 0"
+                        coinName.get(2) + " PriorityBlockingQueue must be 0"
                 )
         );
     }

--- a/price/src/test/java/org/coin/price/queue/PriceMessageWindowBlockingQueueTest.java
+++ b/price/src/test/java/org/coin/price/queue/PriceMessageWindowBlockingQueueTest.java
@@ -1,0 +1,114 @@
+package org.coin.price.queue;
+
+import org.coin.price.dto.CryptoCoin;
+import org.coin.price.dto.CryptoCoinComparator;
+import org.coin.price.dto.PriceApiRequest;
+import org.coin.price.event.PriceMessageProduceEvent;
+import org.jeasy.random.EasyRandom;
+import org.jeasy.random.EasyRandomParameters;
+import org.jeasy.random.FieldPredicates;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.*;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class PriceMessageWindowBlockingQueueTest {
+    private ExecutorService produceExecutorService;
+    private ExecutorService consumeExecutorService;
+    private EasyRandom generator;
+    private PriceMessageWindowBlockingQueue priceMessageBlockingQueue = new PriceMessageWindowBlockingQueue();
+    private ConcurrentHashMap<String, PriorityBlockingQueue<CryptoCoin>> priceHashMapPriorityQueue = new ConcurrentHashMap<>();
+    private ArrayList<String> coinName = new ArrayList<>();
+
+    @BeforeEach
+    void beforeEach() {
+        produceExecutorService = Executors.newScheduledThreadPool(100);
+        consumeExecutorService = Executors.newScheduledThreadPool(100);
+
+        coinName.addAll(List.of("BTC", "ETH", "ETC"));
+        priceHashMapPriorityQueue.put(coinName.get(0), new PriorityBlockingQueue<>(100, new CryptoCoinComparator()));
+        priceHashMapPriorityQueue.put(coinName.get(1), new PriorityBlockingQueue<>(100, new CryptoCoinComparator()));
+        priceHashMapPriorityQueue.put(coinName.get(2), new PriorityBlockingQueue<>(100, new CryptoCoinComparator()));
+        ReflectionTestUtils.setField(priceMessageBlockingQueue, "priceHashMapPriorityQueue", priceHashMapPriorityQueue);
+        ReflectionTestUtils.setField(priceMessageBlockingQueue, "coins", coinName);
+        ReflectionTestUtils.setField(priceMessageBlockingQueue,"windowSize", 5);
+    }
+
+    @Test
+    @DisplayName("consume - success - 5 window-size, 4 types price")
+    void should_consumeThreadSafe_when_validRequest10000WindowSize5PriceType4() throws InterruptedException {
+        // given
+        EasyRandomParameters parameters = new EasyRandomParameters()
+                .randomize(FieldPredicates.named("closing_price"), () -> String.valueOf(generator.nextInt(10, 14)))
+                .randomize(String.class, () -> coinName.get(generator.nextInt(0, 3)))
+                .randomize(FieldPredicates.named("timestamp"), System::currentTimeMillis);
+
+        generator = new EasyRandom(parameters);
+
+        int size = 0;
+        for (int i = 0; i < 10000; i++) {
+            PriceApiRequest request = generator.nextObject(PriceApiRequest.class);
+            PriceMessageProduceEvent event = PriceMessageProduceEvent.of(request);
+
+            size += event.priceDataMap().keySet().size();
+
+            produceExecutorService.submit(() -> {
+                priceMessageBlockingQueue.produce(event);
+            });
+        }
+
+        produceExecutorService.shutdown();
+        assertTrue(produceExecutorService.awaitTermination(60, TimeUnit.SECONDS), "timeout.");
+        System.out.println("produce success, size : " + size);
+
+        AtomicInteger actualSize = new AtomicInteger();
+
+        // when
+        for (int i = 0; i < 20; i++) {
+            consumeExecutorService.submit(() -> {
+                while (true) {
+                    List<CryptoCoin> consume = priceMessageBlockingQueue.consume();
+                    actualSize.addAndGet(consume.size());
+                    if (consume.isEmpty()) {
+                        break;
+                    }
+                }
+            });
+        }
+
+        consumeExecutorService.shutdown();
+        assertTrue(consumeExecutorService.awaitTermination(60, TimeUnit.SECONDS), "timeout.");
+
+        // then
+        assertAll(
+                "PriceMessageWindowBlockingQueue consume test",
+                () -> assertEquals(
+                        12,
+                        actualSize.get(),
+                        "size diff"
+                ),
+                () -> assertEquals(
+                        0,
+                        priceHashMapPriorityQueue.get(coinName.get(0)).size(),
+                        coinName.get(0) + " PriorityBlockingQueue must be 0"
+                ),
+                () -> assertEquals(
+                        0,
+                        priceHashMapPriorityQueue.get(coinName.get(1)).size(),
+                        coinName.get(1) + " PriorityBlockingQueue must be 0"
+                ),
+                () -> assertEquals(
+                        0,
+                        priceHashMapPriorityQueue.get(coinName.get(2)).size(),
+                        coinName.get(2) + " PriorityBlockingQueue must be 0"
+                )
+        );
+    }
+}


### PR DESCRIPTION
# PR 설명
메시지 큐의 성능을 개선하였습니다.

## 변경 사항
[//]: # (변경된 내용을 목록 형태로 간략하게 기술해주세요.)
- tunbling window 개념을 사용하여 메시지 큐의 기능을 개선하였습니다.

## 배경
[//]: # (변경의 배경 및 목적을 설명해주세요.)
250ms 마다 가격을 불러올 떄, 가격이 같은 경우에도 Redis 에서 거래 데이터를 찾는것은 성능상 문제가 되기에 이를 개선하였습니다.
![image](https://github.com/O0oO0Oo/Coin/assets/110446760/f668606d-a74e-4eac-9384-7deba6dd793e)


## 관련 이슈
[//]: # (해당 PR이 해결하고자 하는 이슈 번호를 기술해주세요. 예: #123)
#10 

## 추가 정보
[//]: # (PR과 관련된 추가 정보가 있다면 기술해주세요.)
- [x] 테스트 코드
